### PR TITLE
Added ISO_DEP_MAX_TRANSCEIVE value to libnfc config

### DIFF
--- a/configs/libnfc-nxp.conf
+++ b/configs/libnfc-nxp.conf
@@ -608,3 +608,7 @@ NXP_TYPEA_UICC_BAUD_RATE=0x00
 #    424kbps maximum supported   - 0x02
 #    848kbps maximum supported   - 0x03
 NXP_TYPEB_UICC_BAUD_RATE=0x00
+
+###############################################################################
+# Extended APDU length for ISO_DEP
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF


### PR DESCRIPTION
Without these setting some NFC Tags can not be read (An exception is thrown which states that the transmitted data is too long).

Since Android 9 the max transceive length for IsoDep Tags are not hardcoded, but can be configured by the NFC provider.

The config value was taken from here (https://github.com/ArrowOS/android_hardware_nxp_nfc/blob/arrow-9.x/halimpl/libnfc-nxp-PN551_example.conf), and with this change, the NFC tags can be read correctly.