### PR TITLE
potter: Update zram values

### DIFF
--- a/rootdir/etc/init.potter.rc
+++ b/rootdir/etc/init.potter.rc
@@ -31,10 +31,10 @@ on property:sys.boot_completed=1
     write /proc/sys/vm/swappiness 100
 
 on property:ro.boot.ram=2GB
-    write /sys/block/zram0/disksize 536870912
+    write /sys/block/zram0/disksize 1073741824
 
 on property:ro.boot.ram=3GB
     write /sys/block/zram0/disksize 805306368
 
 on property:ro.boot.ram=4GB
-    write /sys/block/zram0/disksize 1073741824
+    write /sys/block/zram0/disksize 536870912


### PR DESCRIPTION
Use more Zram (1024MB) for 2GB RAM variant and less (512MB) for 4GB variant.